### PR TITLE
Remove json submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/json"]
-	path = third-party/json
-	url = https://github.com/nlohmann/json.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,10 @@ if(WIN32)
 endif(WIN32)
 MESSAGE(STATUS "OS_TYPE=" ${OS_TYPE})
 
+include(FetchContent)
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
+
 add_library(
     hako STATIC
     hako/hako_impl.cpp
@@ -39,6 +43,6 @@ target_include_directories(
     PRIVATE /mingw64/include
     PRIVATE ${PROJECT_SOURCE_DIR}/include
     PRIVATE ${PROJECT_SOURCE_DIR}/hako
-    PRIVATE ${PROJECT_SOURCE_DIR}/../third-party/json/single_include
+    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
 )
 


### PR DESCRIPTION
jsonライブラリをサブモジュールでなく，CMakeのFetch contentってやつに切り替えてみました．ライブラリ自体は小さいのですが，git履歴を全部引っ張ってくるのはちょっと大げさなので，多少cloneが軽くなるかと．
（新幹線の中でCloneしようとしたら，このライブラリの箇所でえらく時間を取られたもので・・．）
hakoniwa-core-cpp-clientのPRと一緒に確認をお願いします．