### PR TITLE
Add README links and core description

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1,0 +1,112 @@
+# Hakoniwa C++ Core API仕様書
+
+このドキュメントでは、本リポジトリで提供されるC++向けHakoniwaコアライブラリのAPI概要を説明します。
+
+## 基本
+- ヘッダ `hako.hpp` をインクルードすることで各種機能を利用できます。
+- 名前空間は `hako` を利用します。
+
+## 初期化・終了
+| 関数 | 説明 |
+| --- | --- |
+| `bool hako::init()` | ライブラリの初期化を行います。共有メモリの準備などを実施します。|
+| `void hako::destroy()` | `init()` で確保したリソースを解放します。|
+
+## コントローラクラス生成
+| 関数 | 説明 |
+| --- | --- |
+| `std::shared_ptr<IHakoMasterController> hako::create_master()` | マスター制御用オブジェクトを生成します。|
+| `std::shared_ptr<IHakoAssetController> hako::create_asset_controller()` | アセット制御用オブジェクトを生成します。|
+| `std::shared_ptr<IHakoSimulationEventController> hako::get_simevent_controller()` | シミュレーションイベント制御オブジェクトを取得します。|
+
+## IHakoMasterController
+`hako_master.hpp` で定義されるインタフェースです。主なメンバーは以下の通りです。
+
+| メソッド | 説明 |
+| --- | --- |
+| `bool execute()` | シミュレーションを1ステップ実行します。|
+| `void set_config_simtime(HakoTimeType max_delay_time_usec, HakoTimeType delta_time_usec)` | シミュレーション時間の設定を行います。|
+| `HakoTimeType get_max_deltay_time_usec()` | 設定された最大遅延時間(usec)を取得します。|
+| `HakoTimeType get_delta_time_usec()` | 時間刻み(usec)を取得します。|
+
+## IHakoAssetController
+`hako_asset.hpp` で定義されるインタフェースです。主なAPIは以下の通りです。
+
+- アセット管理
+  - `bool asset_register(const std::string& name, AssetCallbackType& callbacks)`
+  - `bool asset_register_polling(const std::string& name)`
+  - `HakoSimulationAssetEventType asset_get_event(const std::string& name)`
+  - `bool asset_unregister(const std::string& name)`
+  - `void notify_simtime(const std::string& name, HakoTimeType simtime)`
+  - `HakoTimeType get_worldtime()`
+
+- フィードバックイベント
+  - `bool start_feedback(const std::string& asset_name, bool isOk)`
+  - `bool stop_feedback(const std::string& asset_name, bool isOk)`
+  - `bool reset_feedback(const std::string& asset_name, bool isOk)`
+
+- PDU通信
+  - `bool create_pdu_channel(HakoPduChannelIdType channel_id, size_t pdu_size)`
+  - `bool create_pdu_lchannel(const std::string& robo_name, HakoPduChannelIdType channel_id, size_t pdu_size)`
+  - `HakoPduChannelIdType get_pdu_channel(const std::string& robo_name, HakoPduChannelIdType channel_id)`
+  - `bool is_pdu_dirty(const std::string& asset_name, const std::string& robo_name, HakoPduChannelIdType channel_id)`
+  - `bool write_pdu(const std::string& asset_name, const std::string& robo_name, HakoPduChannelIdType channel_id, const char* pdu_data, size_t len)`
+  - `bool write_pdu_for_external(const std::string& robo_name, HakoPduChannelIdType channel_id, const char* pdu_data, size_t len)`
+  - `bool read_pdu(const std::string& asset_name, const std::string& robo_name, HakoPduChannelIdType channel_id, char* pdu_data, size_t len)`
+  - `bool read_pdu_for_external(const std::string& robo_name, HakoPduChannelIdType channel_id, char* pdu_data, size_t len)`
+  - `void notify_read_pdu_done(const std::string& asset_name)`
+  - `void notify_write_pdu_done(const std::string& asset_name)`
+  - `bool is_pdu_sync_mode(const std::string& asset_name)`
+  - `bool is_simulation_mode()`
+  - `bool is_pdu_created()`
+  - `bool write_pdu_nolock(const std::string& robo_name, HakoPduChannelIdType channel_id, const char* pdu_data, size_t len)`
+  - `bool read_pdu_nolock(const std::string& robo_name, HakoPduChannelIdType channel_id, char* pdu_data, size_t len)`
+
+## IHakoSimulationEventController
+`hako_simevent.hpp` で定義されるインタフェースです。
+
+| メソッド | 説明 |
+| --- | --- |
+| `HakoSimulationStateType state()` | 現在のシミュレーション状態を取得します。|
+| `bool start()` | シミュレーション開始イベントを発行します。|
+| `bool stop()` | シミュレーション停止イベントを発行します。|
+| `bool reset()` | シミュレーションリセットイベントを発行します。|
+| `bool assets(std::vector<std::shared_ptr<std::string>>& asset_list)` | 登録済みアセット名一覧を取得します。|
+| `HakoPduChannelIdType get_pdu_channel(const std::string& asset_name, HakoPduChannelIdType channel_id)` | 指定資産のPDUチャンネルIDを取得します。|
+| `bool write_pdu(HakoPduChannelIdType channel_id, const char* pdu_data, size_t len)` | PDUデータを書き込みます。|
+| `bool read_pdu(HakoPduChannelIdType channel_id, char* pdu_data, size_t len)` | PDUデータを読み込みます。|
+| `size_t pdu_size(HakoPduChannelIdType channel_id)` | 指定チャンネルのPDUサイズを取得します。|
+| `void print_master_data()` | マスターが保持する各種情報を標準出力へ表示します。|
+| `void print_memory_log()` | 共有メモリ上に記録されたログを表示します。|
+
+## 主要データ型
+`types/hako_types.hpp` で定義される主な型は以下の通りです。
+
+- `HakoTimeType` : 時刻（マイクロ秒）を表す 64bit 整数。
+- `HakoAssetIdType` : アセットIDを表す 32bit 整数。
+- `HakoPduChannelIdType` : PDUチャネルIDを表す 32bit 整数。
+- `HakoSimulationStateType` : シミュレーション状態を示す列挙体。
+- `HakoSimulationAssetEventType` : アセット向けイベント種別を示す列挙体。
+- `HakoFixedStringType` : 固定長文字列構造体。
+- `AssetCallbackType` : アセットの start/stop/reset コールバックを保持する構造体。
+
+## ログ出力
+`hako_log.hpp` では以下のマクロが提供されています。
+
+- `HAKO_LOG_INFO(...)`
+- `HAKO_LOG_WARN(...)`
+- `HAKO_LOG_ERROR(...)`
+
+いずれも内部で `hako::log::add()` を呼び出し、ログを共有メモリへ追加します。ロック区間からの呼び出しはデッドロックの恐れがあるため注意が必要です。
+
+## 定数
+設定値は `config/hako_config.hpp` に定義されています。主な定数は以下の通りです。
+
+- `HAKO_FIXED_STRLEN_MAX` : 固定長文字列の最大長。
+- `HAKO_DATA_MAX_ASSET_NUM` : 登録可能なアセット数。
+- `HAKO_PDU_CHANNEL_MAX` : PDUチャンネル上限数。
+- `HAKO_ASSET_TIMEOUT_USEC` : アセットのタイムアウト値。
+
+## 参考サンプル
+`sample/base-procs` 配下に基本的なマスター・アセット・コマンドツールの実装例があります。実際の利用方法についてはこれらのサンプルを参照してください。
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 [![Hakoniwa-core-cpp](https://github.com/toppers/hakoniwa-core-cpp/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/toppers/hakoniwa-core-cpp/actions/workflows/build_and_test.yml)
 
+Hakoniwa-core-cpp は **シミュレーションハブの本体** となるコアライブラリです。共有メモリを利用したスタック構造により、アセット間で高速な PDU データ通信と時刻同期を実現しています。
+
+## Documentation
+- [API Specification](API_SPEC.md)
+- [Shared Memory Layout](SHARED_MEMORY_SPEC.md)
+
+## Stack Overview
+1. Shared memory layer manages master data and PDU buffers.
+2. Controller interfaces (master / asset / event) provide the public API.
+3. Sample processes under `sample/` demonstrate typical usage.
+
 ## Required
 - If Using Google Test
   - sudo apt-get install libgtest-dev

--- a/SHARED_MEMORY_SPEC.md
+++ b/SHARED_MEMORY_SPEC.md
@@ -1,0 +1,96 @@
+# Hakoniwa 共有メモリデータ構造仕様
+
+Hakoniwaコアライブラリでは、マスターと各アセット間で共有メモリを介して状態やPDUデータを共有します。本ドキュメントではそのレイアウトを示します。
+
+## 共有メモリID
+
+`hako_config.hpp` で以下のIDが定義されています。
+
+- `HAKO_SHARED_MEMORY_ID_0` : マスター情報(`HakoMasterDataType`)
+- `HAKO_SHARED_MEMORY_ID_1` : PDUデータ領域(`HakoPduData`)
+- `HAKO_SHARED_MEMORY_ID_2` : 拡張用
+
+## HakoMasterDataType
+
+マスター用共有メモリ( `HAKO_SHARED_MEMORY_ID_0` )に配置される構造体です。
+
+```cpp
+struct HakoMasterDataType {
+    pid_type                master_pid;
+    HakoSimulationStateType state;
+    HakoTimeSetType         time_usec;
+    uint32_t                asset_num;
+    HakoAssetEntryType      assets[HAKO_DATA_MAX_ASSET_NUM];
+    HakoAssetEntryEventType assets_ev[HAKO_DATA_MAX_ASSET_NUM];
+    HakoPduMetaDataType     pdu_meta_data;
+    HakoLogDataType         log;
+};
+```
+
+### フィールド概要
+
+- **master_pid** : マスタープロセスのPID
+- **state** : シミュレーション状態
+- **time_usec** : `max_delay` / `delta` / `current` を保持する時刻情報
+- **asset_num** : 登録済みアセット数
+- **assets[]** : アセットの静的情報(ID, 名前, 種別, コールバック)
+- **assets_ev[]** : アセットの動的情報(PID, イベント, ハートビートなど)
+- **pdu_meta_data** : PDUチャンネル管理情報(後述)
+- **log** : 共有メモリ上のリングバッファログ
+
+## HakoPduMetaDataType
+
+`HakoMasterDataType` 内で使用され、PDUデータ( `HAKO_SHARED_MEMORY_ID_1` )の配置やアクセス状態を管理します。
+
+```cpp
+struct HakoPduMetaDataType {
+    HakoTimeModeType    mode;
+    HakoAssetIdType     asset_num;
+    HakoAssetIdType     pdu_sync_asset_id;
+    bool                asset_pdu_check_status[HAKO_DATA_MAX_ASSET_NUM];
+    int32_t             channel_num;
+    bool                is_dirty[HAKO_PDU_CHANNEL_MAX];
+    bool                is_rbusy[HAKO_DATA_MAX_ASSET_NUM][HAKO_PDU_CHANNEL_MAX];
+    bool                is_rbusy_for_external[HAKO_PDU_CHANNEL_MAX];
+    bool                is_wbusy[HAKO_PDU_CHANNEL_MAX];
+    HakoPduChannelType  channel[HAKO_PDU_CHANNEL_MAX];
+    uint32_t            pdu_read_version[HAKO_DATA_MAX_ASSET_NUM][HAKO_PDU_CHANNEL_MAX];
+    uint32_t            pdu_write_version[HAKO_PDU_CHANNEL_MAX];
+    HakoPduChannelMapType channel_map[HAKO_PDU_CHANNEL_MAX];
+};
+```
+
+各フィールドの役割は以下の通りです。
+
+- **mode** : マスター駆動かアセット駆動かを示すモード
+- **asset_num** : PDU同期対象となるアセット数
+- **pdu_sync_asset_id** : 同期に利用するアセットID
+- **asset_pdu_check_status[]** : アセット毎のPDU送信確認フラグ
+- **channel_num** : 使用しているPDUチャネル数
+- **is_dirty[]** : チャネル毎の更新有無
+- **is_rbusy[][] / is_wbusy[]** : 読み書き中フラグ
+- **channel[]** : 各チャネルの `offset` と `size`
+- **pdu_read_version[][] / pdu_write_version[]** : 版数カウンタによる同期
+- **channel_map[]** : 論理チャネル管理用マッピング
+
+## PDUデータ領域
+
+実際のPDUバイト列は `HAKO_SHARED_MEMORY_ID_1` に確保されます。`HakoPduData::create()` で生成され、`pdu_meta_data.channel[i].offset` / `size` に従って連続配置されます。
+
+```
+offset = channel[i].offset
+size   = channel[i].size
+pdu_memory[offset .. offset + size - 1] がチャネル i のデータ
+```
+
+リセット時には`HakoPduData::reset()`により初期化されます。読み書きAPIは`is_rbusy`や`is_wbusy`といったフラグを参照しながら排他制御を行います。
+
+## ログバッファ
+
+`HakoMasterDataType`末尾の`HakoLogDataType`は固定長のログ領域であり、`HAKO_LOGGER_LOGNUM`件のエントリをリングバッファ方式で保持します。
+
+## 参考
+
+- `src/hako/data/hako_base_data.hpp`
+- `src/hako/data/hako_master_data.hpp`
+- `src/hako/data/hako_pdu_data.hpp`


### PR DESCRIPTION
## Summary
- link API and shared memory specs from README
- describe hakoniwa-core-cpp as the main simulation hub body
- mention high-speed PDU data communication and time sync over shared memory
- outline stack layers

## Testing
- `./build.bash test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68676b5e13488322b41b33779cd72dd8